### PR TITLE
refactor getNumOfBytes helper fun to account for large files

### DIFF
--- a/wcTool/Ccwc.kt
+++ b/wcTool/Ccwc.kt
@@ -1,10 +1,22 @@
 import java.io.File
+import java.io.FileInputStream
 import java.nio.charset.Charset
 
 fun main (args: Array<String>) {
     //helper functions
-    fun getNumOfBytes(file: File): Long {
-        return file.length()
+    fun getNumOfBytes(file: File, fileChunkSize: Int = 1024 * 1024): Long {
+        var totalByte: Long = 0
+
+        //read files in increments for scalability
+        FileInputStream(file).use { stream ->
+            val buffer = ByteArray(fileChunkSize)
+            var byteRead: Int
+
+            while (stream.read(buffer).also { byteRead = it } != -1) {
+                totalByte += byteRead
+            }
+        }
+        return totalByte
     }
 
     fun getNumOfLines(file: File): Int {


### PR DESCRIPTION
Implemented file reads by increments, to account for instances where files are large.